### PR TITLE
ランキングの合計ポイント降順でデータ取得API

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -21,20 +21,21 @@ model User {
   photoUrl String
   scores Score[]
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 
   @@index([uid])
 }
 
 model Score {
   id  Int  @id @default(autoincrement())
-  point String
-  answerTime DateTime
+  point Int
+  answerTime DateTime @default(now())
   similarity Float
   assignmentId Int
   userId Int
+  imageUrl String
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 
   user User @relation(fields: [userId], references: [id])
   assignment Assignment @relation(fields: [assignmentId], references: [id])
@@ -45,7 +46,7 @@ model Assignment {
   wordId Int
   date DateTime @default(now())
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 
   word Word @relation(fields: [wordId], references: [id])
   scores Score[]
@@ -57,7 +58,7 @@ model Word {
   japanese String
   difficulty Int
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now())  @updatedAt
 
   assignment Assignment[]
 }

--- a/app/src/app/api/scores/all/route.ts
+++ b/app/src/app/api/scores/all/route.ts
@@ -3,21 +3,50 @@ import { prisma } from "@lib/prisma";
 export async function GET() {
 
 	const scores = await prisma.score.findMany({
-		include: { user: true, assignment: {
-			include: {
-				word: true
-			}
-		} },
+		orderBy: {
+            id: "asc"
+        },
+        select: {
+            id: true,
+            point: true,
+            answerTime: true,
+            similarity: true,
+            imageUrl: true,
+            createdAt: true,
+            updatedAt: true,
+            user: {
+                select: {
+                    uid: true,
+                    name: true,
+                    email: true,
+                    photoUrl: true,
+                }
+            },
+            assignment: {
+                select: {
+                    wordId: true,
+                    date: true,
+                    word: {
+                        select: {
+                            english: true,
+                            japanese: true,
+                            difficulty: true
+                        }
+                    }
+                }
+            }
+        }
 	});
 
+	// 空の場合、空配列で返す
 	if (!scores) {
-		return new Response(JSON.stringify({ message: "Not Found" }), {
-			status: 404,
+		return new Response(JSON.stringify([]), {
+			status: 200,
 			headers: { "Content-Type": "application/json" },
 		});
 	}
 
-	return new Response(JSON.stringify(scores), {
+	return new Response(JSON.stringify(scores, null, 2), {
 		status: 200,
 		headers: { "Content-Type": "application/json" },
 	});

--- a/app/src/app/api/scores/all/route.ts
+++ b/app/src/app/api/scores/all/route.ts
@@ -2,52 +2,32 @@ import type { RankingScores } from "@/types";
 import { prisma } from "@lib/prisma";
 
 export async function GET() {
-	const scores = await prisma.score.findMany({
-		include: {
-			user: true,
-			assignment: {
-				include: {
-					word: true,
-				},
-			},
-		},
-	});
-
 	const userScores = await prisma.user.findMany({
 		select: {
 			id: true,
 			name: true,
+			uid: true,
+			photoUrl: true,
 			scores: {
 				select: {
 					point: true,
 				},
 			},
 		},
+		distinct: ['uid'],
 	});
 
-	const scoreDetails: RankingScores[] = scores
-		.map((score) => {
-			// ユーザーの合計ポイント
-			const user = userScores.find((user) => user.id === score.id);
-			const sumScore = user ? user.scores.reduce((sum, score) => sum + score.point, 0) : 0;
+	const scoreDetails: RankingScores[] = userScores.map((userScore) => {
+		const sumScore = userScore.scores.reduce((sum, score) => sum + score.point, 0);
 
-			const rankingScore: RankingScores = {
-				id: score.id,
-				userName: score.user?.name || "",
-				imageUrl: score.imageUrl,
-				totalPoint: sumScore,
-			};
-			return rankingScore;
-		})
-		.sort((a, b) => b.totalPoint - a.totalPoint);
-
-	// 空の場合、空配列で返す
-	if (!scores) {
-		return new Response(JSON.stringify([]), {
-			status: 200,
-			headers: { "Content-Type": "application/json" },
-		});
-	}
+		const rankingScore: RankingScores = {
+			id: userScore.id,
+			userName: userScore?.name || "",
+			imageUrl: userScore.photoUrl,
+			totalPoint: sumScore,
+		};
+		return rankingScore;
+	}).sort((a, b) => b.totalPoint - a.totalPoint)
 
 	return new Response(JSON.stringify(scoreDetails), {
 		status: 200,

--- a/app/src/app/api/scores/all/route.ts
+++ b/app/src/app/api/scores/all/route.ts
@@ -1,0 +1,24 @@
+import { prisma } from "@lib/prisma";
+
+export async function GET() {
+
+	const scores = await prisma.score.findMany({
+		include: { user: true, assignment: {
+			include: {
+				word: true
+			}
+		} },
+	});
+
+	if (!scores) {
+		return new Response(JSON.stringify({ message: "Not Found" }), {
+			status: 404,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	return new Response(JSON.stringify(scores), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}

--- a/app/src/app/api/scores/all/route.ts
+++ b/app/src/app/api/scores/all/route.ts
@@ -1,41 +1,40 @@
 import { prisma } from "@lib/prisma";
 
 export async function GET() {
-
 	const scores = await prisma.score.findMany({
 		orderBy: {
-            id: "asc"
-        },
-        select: {
-            id: true,
-            point: true,
-            answerTime: true,
-            similarity: true,
-            imageUrl: true,
-            createdAt: true,
-            updatedAt: true,
-            user: {
-                select: {
-                    uid: true,
-                    name: true,
-                    email: true,
-                    photoUrl: true,
-                }
-            },
-            assignment: {
-                select: {
-                    wordId: true,
-                    date: true,
-                    word: {
-                        select: {
-                            english: true,
-                            japanese: true,
-                            difficulty: true
-                        }
-                    }
-                }
-            }
-        }
+			id: "asc",
+		},
+		select: {
+			id: true,
+			point: true,
+			answerTime: true,
+			similarity: true,
+			imageUrl: true,
+			createdAt: true,
+			updatedAt: true,
+			user: {
+				select: {
+					uid: true,
+					name: true,
+					email: true,
+					photoUrl: true,
+				},
+			},
+			assignment: {
+				select: {
+					wordId: true,
+					date: true,
+					word: {
+						select: {
+							english: true,
+							japanese: true,
+							difficulty: true,
+						},
+					},
+				},
+			},
+		},
 	});
 
 	// 空の場合、空配列で返す

--- a/app/src/types/index.tsx
+++ b/app/src/types/index.tsx
@@ -66,10 +66,17 @@ export type Word = {
 
 export type ScoreDetail = {
 	id: number;
-	assignment: String;
+	assignment: string;
 	answerIntervalTime: number;
 	userName: string;
 	imageUrl: string;
 	point: number;
 	similarity: number;
+};
+
+export type RankingScores = {
+	id: number;
+	userName: string;
+	totalPoint: number;
+	imageUrl: string;
 };


### PR DESCRIPTION
## 概要

- このプルリクエストの目的や背景を簡単に説明してください。
- GetAllScores
    - ランキング画面・全体用
    - ランキングの全件取得
    - Users、Scores、Assginments、Wordsをjoin
    - `/api/score/all`
  すべてを結合して全件取得しました。

## 変更内容

- どのような変更を行ったのか具体的に記述してください。
schema.prismaの修正
くぼのPRと同じだから見なくて良いです

app/api/scores/all/index.tsを新しく作成しました。
ps.
返す値はid,userName,totalPoint,imageUrlに変更しました。
ポイントの合計を加算させました。また、合計ポイントの降順に返すようにしました。

## 動作確認

- どのような手順で動作確認を行ったのか記述してください。
ブラウザで`http://localhost:3000/api/scores/all`で全件取得されるか
`curl http://localhost:3000/api/scores/all`
テストデータもくぼのprのものを借用
![image](https://github.com/user-attachments/assets/b32fcbc3-0243-4cfc-9bcf-c3716c3c3369)
## 関連するIssue

- 関連するIssue番号を記載してください。例: `#123`

## 備考

- その他、レビュワーに伝えたいことがあれば記述してください。
