### PR TITLE
ユーザーページの作成

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^18",
         "react-camera-pro": "^1.4.0",
         "react-dom": "^18",
+        "react-icons": "^5.3.0",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -6986,6 +6987,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "react": "^18",
     "react-camera-pro": "^1.4.0",
     "react-dom": "^18",
+    "react-icons": "^5.3.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/app/src/app/api/score/me/[uid]/route.ts
+++ b/app/src/app/api/score/me/[uid]/route.ts
@@ -33,10 +33,13 @@ export async function GET(req: NextRequest) {
 
 	// スコア情報を整形
 	const myScoreDetails: MyScoreDetail[] = myScores.map((score) => {
-		const answerIntervalTimeMilliseconds =
-			score.answerTime.getTime() - score.assignment.date.getTime();
+		const answerIntervalTimeMilliseconds = score.assignment
+			? score.answerTime.getTime() - score.assignment.date.getTime()
+			: 0;
 		const answerIntervalTimeSeconds = answerIntervalTimeMilliseconds / 1000;
-		const word = words.find((word) => word.id === score.assignment.wordId);
+		const word = score.assignment
+			? words.find((word) => word.id === score.assignment?.wordId)
+			: undefined;
 		// 時間差を「○日前」「○時間前」「○分前」の形式に変換
 		const timeAgoString = timeAgo(score.answerTime);
 		const scoreDetail: MyScoreDetail = {
@@ -48,9 +51,10 @@ export async function GET(req: NextRequest) {
 			point: score?.point || 0,
 			similarity: score.similarity,
 			answerTime: timeAgoString,
+			date: score.answerTime.toISOString(),
 		};
 		return scoreDetail;
-	})
+	});
 
 	return new Response(JSON.stringify(myScoreDetails), {
 		status: 200,
@@ -60,23 +64,29 @@ export async function GET(req: NextRequest) {
 
 function timeAgo(date: Date): string {
 	const now = new Date();
-  
+
 	// 各日付を「年・月・日」単位にする（時刻を無視）
 	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-	const targetDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  
+	const targetDay = new Date(
+		date.getFullYear(),
+		date.getMonth(),
+		date.getDate(),
+	);
+
 	// ミリ秒差を計算
 	const diffTime = now.getTime() - date.getTime();
-	const diffDays = Math.floor((today.getTime() - targetDay.getTime()) / (1000 * 60 * 60 * 24));
-	
+	const diffDays = Math.floor(
+		(today.getTime() - targetDay.getTime()) / (1000 * 60 * 60 * 24),
+	);
+
 	const diffMinutes = Math.floor(diffTime / (1000 * 60));
 	const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
-  
+
 	if (diffDays > 0) {
-	  return `${diffDays}日前`; // 日付が違えば「○日前」
-	} else if (diffHours > 0) {
-	  return `${diffHours}時間前`; // 同日内なら「○時間前」
-	} else {
-	  return `${diffMinutes}分前`; // 1時間未満なら「○分前」
+		return `${diffDays}日前`; // 日付が違えば「○日前」
 	}
-  }
+	if (diffHours > 0) {
+		return `${diffHours}時間前`; // 同日内なら「○時間前」
+	}
+	return `${diffMinutes}分前`; // 1時間未満なら「○分前」
+}

--- a/app/src/app/api/score/me/[uid]/route.ts
+++ b/app/src/app/api/score/me/[uid]/route.ts
@@ -6,13 +6,21 @@ import type { MyScoreDetail } from "@/types";
 function calculateStreakDays(dates: Date[]): number {
 	if (dates.length === 0) return 0;
 
-	dates.sort((a, b) => b.getTime() - a.getTime());
-	let streak = 1;
-	const currentDate = new Date(dates[0]);
+	// 日付をの重複を除去
+	const uniqueDateStrings = Array.from(
+		new Set(dates.map((date) => date.toDateString())),
+	);
+	// 日付オブジェクトに再変換
+	const uniqueDates = uniqueDateStrings.map((dateStr) => new Date(dateStr));
 
-	for (let i = 1; i < dates.length; i++) {
+	uniqueDates.sort((a, b) => b.getTime() - a.getTime()); // 降順にソート
+
+	let streak = 1;
+	const currentDate = new Date(uniqueDates[0]);
+
+	for (let i = 1; i < uniqueDates.length; i++) {
 		currentDate.setDate(currentDate.getDate() - 1);
-		if (dates[i].toDateString() === currentDate.toDateString()) {
+		if (uniqueDates[i].toDateString() === currentDate.toDateString()) {
 			streak++;
 		} else {
 			break;
@@ -21,7 +29,6 @@ function calculateStreakDays(dates: Date[]): number {
 
 	return streak;
 }
-
 // 時間差を「○日前」「○時間前」「○分前」に変換する関数
 function timeAgo(date: Date): string {
 	const now = new Date();

--- a/app/src/app/api/score/me/[uid]/route.ts
+++ b/app/src/app/api/score/me/[uid]/route.ts
@@ -1,96 +1,120 @@
 import type { NextRequest } from 'next/server';
 import { prisma } from "@lib/prisma";
-import type { MyScoreDetail, Score } from "@/types";
+import type { MyScoreDetail } from "@/types";
+
+// 連続日数を計算する関数
+function calculateStreakDays(dates: Date[]): number {
+	if (dates.length === 0) return 0;
+
+	dates.sort((a, b) => b.getTime() - a.getTime());
+	let streak = 1;
+	const currentDate = new Date(dates[0]);
+
+	for (let i = 1; i < dates.length; i++) {
+		currentDate.setDate(currentDate.getDate() - 1);
+		if (dates[i].toDateString() === currentDate.toDateString()) {
+			streak++;
+		} else {
+			break;
+		}
+	}
+
+	return streak;
+}
+
+// 時間差を「○日前」「○時間前」「○分前」に変換する関数
+function timeAgo(date: Date): string {
+	const now = new Date();
+	const diffTime = now.getTime() - date.getTime();
+	const diffMinutes = Math.floor(diffTime / (1000 * 60));
+	const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
+	const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+	if (diffDays > 0) return `${diffDays}日前`;
+	if (diffHours > 0) return `${diffHours}時間前`;
+	return `${diffMinutes}分前`;
+}
 
 // GETメソッドのハンドラ関数
 export async function GET(req: NextRequest) {
-	// クエリパラメータを取得
 	const { pathname, searchParams } = new URL(req.url || "");
 	const uid = pathname.split("/").pop() || "";
 	const limitParam = searchParams.get("limit");
-	const limit = limitParam ? Number.parseInt(limitParam) : 3;
-	const all = searchParams.get("all") === "true";
+	const allParam = searchParams.get("all");
 
-	if(uid === ""){
+	let limit = 3;
+
+	if (allParam === "true") {
+		limit = -1;
+	} else if (limitParam) {
+		limit = Number.parseInt(limitParam);
+	}
+
+	if (!uid) {
 		return new Response(JSON.stringify({ message: "Not Found" }), {
 			status: 404,
 			headers: { "Content-Type": "application/json" },
 		});
 	}
 
-	// ユーザー情報を取得
-	const me = await prisma.user.findFirst({
-		where: { uid: uid },
+	// ユーザー情報とスコア情報を取得
+	const userData = await prisma.user.findUnique({
+		where: { uid },
+		include: {
+			scores: {
+				include: {
+					assignment: {
+						include: { word: true },
+					},
+				},
+				orderBy: { answerTime: "desc" },
+			},
+		},
 	});
 
-	// ユーザーのスコア情報を取得
-	const myScores: Score[] = await prisma.score.findMany({
-		where: { userId: me?.id },
-		include: { user: true, assignment: true },
-		...(all ? {} : { take: limit }),
-		orderBy: { answerTime: "desc" },
-	});
+	if (!userData) {
+		return new Response(JSON.stringify({ message: "User Not Found" }), {
+			status: 404,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
 
-	// 単語情報を取得（scoreの中にあるassignmentの中にあるwordIdを使って取得するため）
-	// TODO この処理をfor文で回すのは非効率なので、修正する
-	const words = await prisma.word.findMany();
+	const allScores = userData.scores;
+
+	// スコアの日付リストを取得
+	const scoreDates = allScores.map((score) => new Date(score.answerTime));
+
+	// 連続日数と最高スコアを計算
+	const streakDays = calculateStreakDays(scoreDates);
+	const highestPoint = Math.max(...allScores.map((score) => score.point));
+
+	// 表示するスコアを決定
+	const scoresToReturn = limit === -1 ? allScores : allScores.slice(0, limit);
 
 	// スコア情報を整形
-	const myScoreDetails: MyScoreDetail[] = myScores.map((score) => {
-		const answerIntervalTimeMilliseconds = score.assignment
-			? score.answerTime.getTime() - score.assignment.date.getTime()
-			: 0;
+	const myScoreDetails: MyScoreDetail[] = scoresToReturn.map((score) => {
+		const answerIntervalTimeMilliseconds =
+			new Date(score.answerTime).getTime() -
+			new Date(score.assignment.date).getTime();
 		const answerIntervalTimeSeconds = answerIntervalTimeMilliseconds / 1000;
-		const word = score.assignment
-			? words.find((word) => word.id === score.assignment?.wordId)
-			: undefined;
-		// 時間差を「○日前」「○時間前」「○分前」の形式に変換
-		const timeAgoString = timeAgo(score.answerTime);
-		const scoreDetail: MyScoreDetail = {
+
+		return {
 			id: score.id,
-			assignment: word?.english || "",
+			assignment: score.assignment.word?.english || "",
 			answerIntervalTime: answerIntervalTimeSeconds,
-			userName: score.user?.name || "",
+			userName: userData.name || "",
 			imageUrl: score.imageUrl,
-			point: score?.point || 0,
+			point: score.point || 0,
+			highestPoint,
 			similarity: score.similarity,
-			answerTime: timeAgoString,
-			date: score.answerTime.toISOString(),
+			answerTime: timeAgo(new Date(score.answerTime)),
+			date: new Date(score.answerTime).toISOString(),
+			streakDays,
 		};
-		return scoreDetail;
 	});
 
 	return new Response(JSON.stringify(myScoreDetails), {
 		status: 200,
 		headers: { "Content-Type": "application/json" },
 	});
-}
-
-function timeAgo(date: Date): string {
-	const now = new Date();
-
-	// 各日付を「年・月・日」単位にする（時刻を無視）
-	const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-	const targetDay = new Date(
-		date.getFullYear(),
-		date.getMonth(),
-		date.getDate(),
-	);
-
-	// ミリ秒差を計算
-	const diffTime = now.getTime() - date.getTime();
-	const diffDays = Math.floor(
-		(today.getTime() - targetDay.getTime()) / (1000 * 60 * 60 * 24),
-	);
-
-	const diffMinutes = Math.floor(diffTime / (1000 * 60));
-	const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
-
-	if (diffDays > 0) {
-		return `${diffDays}日前`; // 日付が違えば「○日前」
-	}
-	if (diffHours > 0) {
-		return `${diffHours}時間前`; // 同日内なら「○時間前」
-	}
-	return `${diffMinutes}分前`; // 1時間未満なら「○分前」
 }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 	}, []);
 
 	return (
-		<div className="flex flex-col h-screen px-4 py-10 bg-gradient-to-t from-gray-300 via-gray-200 to-gray-50">
+		<div className="flex flex-col h-full px-4 py-10 bg-gradient-to-t from-gray-300 via-gray-200 to-gray-50">
 			<div className="flex flex-col items-center justify-center space-y-6">
 				<Card
 					className="flex flex-col items-center justify-around aspect-square w-full max-w-72 p-6 backdrop-blur-sm"

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -14,12 +14,18 @@ export default function Home() {
 
 	useEffect(() => {
 		const fetchData = async () => {
-			const uid = localStorage.getItem("userID");
-			if (!uid) {
+			const userIdString = localStorage.getItem("userID");
+			if (!userIdString) {
 				return;
 			}
 
 			try {
+				const userData = JSON.parse(userIdString);
+				const uid = userData.uid;
+				if (!uid) {
+					throw new Error("User ID not found");
+				}
+
 				const response = await fetch(`/api/score/me/${uid}`);
 				if (!response.ok) {
 					throw new Error("データの取得に失敗しました");
@@ -33,13 +39,6 @@ export default function Home() {
 
 		fetchData();
 	}, []);
-
-	function calculateDaysAgo(date: Date): string {
-		const today = new Date();
-		const diffTime = Math.abs(today.getTime() - date.getTime());
-		const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-		return `${diffDays}日前`;
-	}
 
 	return (
 		<div className="flex flex-col h-full px-4 py-10">
@@ -69,30 +68,35 @@ export default function Home() {
 						</Button>
 					</div>
 				</Card>
-				<Card className="flex flex-col items-center aspect-square w-10/12 max-w-72 p-6 bg-white/80 backdrop-blur-sm overflow-y-auto">
+				<Card className="flex flex-col items-center aspect-square w-10/12 p-6 bg-white/80 backdrop-blur-sm">
 					<h2 className="text-lg font-semibold mb-4">過去のチャレンジ</h2>
-					{myScore.map((score) => (
-						<div
-							key={score.id}
-							className="flex w-full items-center mb-2 border rounded-md"
-						>
-							<img
-								src={score.imageUrl}
-								alt="チャレンジ画像"
-								className="w-1/4 h-auto rounded-l-md"
-							/>
-							<div className="flex flex-col items-start justify-center w-1/2 text-xs">
-								<div className="pl-4 flex flex-col gap-1">
-									<p className="font-bold">{score.assignment}</p>
-									<div className="flex items-center gap-1">
-										<ClockIcon className="w-3 h-3" />
-										<p className="pb-0.5">{score.answerTime}</p>
+					{myScore
+						.sort(
+							(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+						)
+						.slice(0, 3)
+						.map((score) => (
+							<div
+								key={score.id}
+								className="flex w-full items-center mb-2 border rounded-md"
+							>
+								<img
+									src={score.imageUrl}
+									alt="チャレンジ画像"
+									className="w-1/4 h-auto rounded-l-md"
+								/>
+								<div className="flex flex-col items-start justify-center w-1/2 text-xs">
+									<div className="pl-4 flex flex-col gap-1">
+										<p className="font-bold">{score.assignment}</p>
+										<div className="flex items-center gap-1">
+											<ClockIcon className="w-3 h-3" />
+											<p className="pb-0.5">{score.answerTime}</p>
+										</div>
 									</div>
 								</div>
+								<p className="w-1/4 text-lg font-bold">{score.point}点</p>
 							</div>
-							<p className="w-1/4 text-lg font-bold">{score.point}点</p>
-						</div>
-					))}
+						))}
 				</Card>
 			</div>
 		</div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -70,33 +70,43 @@ export default function Home() {
 				</Card>
 				<Card className="flex flex-col items-center aspect-square w-10/12 p-6 bg-white/80 backdrop-blur-sm">
 					<h2 className="text-lg font-semibold mb-4">過去のチャレンジ</h2>
-					{myScore
-						.sort(
-							(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-						)
-						.slice(0, 3)
-						.map((score) => (
-							<div
-								key={score.id}
-								className="flex w-full items-center mb-2 border rounded-md"
-							>
-								<img
-									src={score.imageUrl}
-									alt="チャレンジ画像"
-									className="w-1/4 h-auto rounded-l-md"
-								/>
-								<div className="flex flex-col items-start justify-center w-1/2 text-xs">
-									<div className="pl-4 flex flex-col gap-1">
-										<p className="font-bold">{score.assignment}</p>
-										<div className="flex items-center gap-1">
-											<ClockIcon className="w-3 h-3" />
-											<p className="pb-0.5">{score.answerTime}</p>
+					{myScore.length === 0 ? (
+						<div className="text-gray-500 text-center py-8">
+							<p>まだチャレンジの記録がありません</p>
+							<p className="text-sm mt-2">
+								新しいチャレンジに挑戦してみましょう！
+							</p>
+						</div>
+					) : (
+						myScore
+							.sort(
+								(a, b) =>
+									new Date(b.date).getTime() - new Date(a.date).getTime(),
+							)
+							.slice(0, 3)
+							.map((score) => (
+								<div
+									key={score.id}
+									className="flex w-full items-center mb-2 border rounded-md"
+								>
+									<img
+										src={score.imageUrl}
+										alt="チャレンジ画像"
+										className="w-1/4 h-auto rounded-l-md"
+									/>
+									<div className="flex flex-col items-start justify-center w-1/2 text-xs">
+										<div className="pl-4 flex flex-col gap-1">
+											<p className="font-bold">{score.assignment}</p>
+											<div className="flex items-center gap-1">
+												<ClockIcon className="w-3 h-3" />
+												<p className="pb-0.5">{score.answerTime}</p>
+											</div>
 										</div>
 									</div>
+									<p className="w-1/4 text-lg font-bold">{score.point}点</p>
 								</div>
-								<p className="w-1/4 text-lg font-bold">{score.point}点</p>
-							</div>
-						))}
+							))
+					)}
 				</Card>
 			</div>
 		</div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 	}, []);
 
 	return (
-		<div className="flex flex-col h-full px-4 py-10">
+		<div className="flex flex-col h-screen px-4 py-10 bg-gradient-to-t from-gray-300 via-gray-200 to-gray-50">
 			<div className="flex flex-col items-center justify-center space-y-6">
 				<Card
 					className="flex flex-col items-center justify-around aspect-square w-full max-w-72 p-6 backdrop-blur-sm"
@@ -84,7 +84,7 @@ export default function Home() {
 								className="flex w-full items-center mb-2 border rounded-md"
 							>
 								<img
-									src={score.imageUrl}
+									src={score.imageUrl || "https://placehold.jp/150x150.png"}
 									alt="チャレンジ画像"
 									className="w-1/4 h-auto rounded-l-md"
 								/>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
 					throw new Error("User ID not found");
 				}
 
-				const response = await fetch(`/api/score/me/${uid}`);
+				const response = await fetch(`/api/score/me/${uid}?limit=3`);
 				if (!response.ok) {
 					throw new Error("データの取得に失敗しました");
 				}
@@ -78,34 +78,28 @@ export default function Home() {
 							</p>
 						</div>
 					) : (
-						myScore
-							.sort(
-								(a, b) =>
-									new Date(b.date).getTime() - new Date(a.date).getTime(),
-							)
-							.slice(0, 3)
-							.map((score) => (
-								<div
-									key={score.id}
-									className="flex w-full items-center mb-2 border rounded-md"
-								>
-									<img
-										src={score.imageUrl}
-										alt="チャレンジ画像"
-										className="w-1/4 h-auto rounded-l-md"
-									/>
-									<div className="flex flex-col items-start justify-center w-1/2 text-xs">
-										<div className="pl-4 flex flex-col gap-1">
-											<p className="font-bold">{score.assignment}</p>
-											<div className="flex items-center gap-1">
-												<ClockIcon className="w-3 h-3" />
-												<p className="pb-0.5">{score.answerTime}</p>
-											</div>
+						myScore.map((score) => (
+							<div
+								key={score.id}
+								className="flex w-full items-center mb-2 border rounded-md"
+							>
+								<img
+									src={score.imageUrl}
+									alt="チャレンジ画像"
+									className="w-1/4 h-auto rounded-l-md"
+								/>
+								<div className="flex flex-col items-start justify-center w-1/2 text-xs">
+									<div className="pl-4 flex flex-col gap-1">
+										<p className="font-bold">{score.assignment}</p>
+										<div className="flex items-center gap-1">
+											<ClockIcon className="w-3 h-3" />
+											<p className="pb-0.5">{score.answerTime}</p>
 										</div>
 									</div>
-									<p className="w-1/4 text-lg font-bold">{score.point}点</p>
 								</div>
-							))
+								<p className="w-1/4 text-lg font-bold">{score.point}点</p>
+							</div>
+						))
 					)}
 				</Card>
 			</div>

--- a/app/src/app/user/page.tsx
+++ b/app/src/app/user/page.tsx
@@ -43,7 +43,7 @@ const UserPage = () => {
 
 	if (!userData) return null;
 	return (
-		<div className="w-screen h-screen flex flex-col gap-4 items-center p-4 pt-10 bg-gradient-to-t from-gray-300 via-gray-200 to-gray-50">
+		<div className="w-screen h-full flex flex-col gap-4 items-center p-4 pt-10 bg-gradient-to-t from-gray-300 via-gray-200 to-gray-50">
 			<div className="flex items-center mb-4">
 				{userData.photoURL ? (
 					<img

--- a/app/src/app/user/page.tsx
+++ b/app/src/app/user/page.tsx
@@ -84,7 +84,7 @@ const UserPage = () => {
 				const userData = JSON.parse(userIdString);
 				setUserData(userData); // LocalStorageのユーザー情報を状態として保存
 
-				const response = await fetch(`/api/score/me/${userData.uid}`);
+				const response = await fetch(`/api/score/me/${userData.uid}?all=true`);
 				if (!response.ok) {
 					throw new Error("データの取得に失敗しました");
 				}

--- a/app/src/app/user/page.tsx
+++ b/app/src/app/user/page.tsx
@@ -129,12 +129,12 @@ const UserPage = () => {
 			<div className="flex justify-center gap-4 w-screen">
 				<Card className="w-40 h-40 flex flex-col items-center justify-center shadow-none">
 					<LuFlame className="h-12 w-12 text-orange-500 mb-2" />
-					<div className="text-3xl font-bold">{streak}日</div>
+					<div className="text-3xl font-bold mb-2">{streak}日</div>
 					<p className="text-xs text-muted-foreground">継続記録</p>
 				</Card>
 				<Card className="w-40 h-40 flex flex-col items-center justify-center shadow-none">
 					<LuTrophy className="h-12 w-12 text-yellow-500 mb-2" />
-					<div className="text-3xl font-bold">{highestScore}</div>
+					<div className="text-3xl font-bold mb-2">{highestScore}</div>
 					<p className="text-xs text-muted-foreground">最高点</p>
 				</Card>
 			</div>

--- a/app/src/app/user/page.tsx
+++ b/app/src/app/user/page.tsx
@@ -103,7 +103,7 @@ const UserPage = () => {
 
 	if (!userData) return null;
 	return (
-		<div className="w-screen h-screen flex flex-col gap-4 items-center p-4 pt-10">
+		<div className="w-screen h-screen flex flex-col gap-4 items-center p-4 pt-10 bg-gradient-to-t from-gray-300 via-gray-200 to-gray-50">
 			<div className="flex items-center mb-4">
 				{userData.photoURL ? (
 					<img
@@ -127,41 +127,50 @@ const UserPage = () => {
 				</div>
 			</div>
 			<div className="flex justify-center gap-4 w-screen">
-				<Card className="w-40 h-40 flex flex-col items-center justify-center shadow-none">
+				<Card className="w-40 h-40 flex flex-col items-center justify-center border-none">
 					<LuFlame className="h-12 w-12 text-orange-500 mb-2" />
 					<div className="text-3xl font-bold mb-2">{streak}日</div>
 					<p className="text-xs text-muted-foreground">継続記録</p>
 				</Card>
-				<Card className="w-40 h-40 flex flex-col items-center justify-center shadow-none">
+				<Card className="w-40 h-40 flex flex-col items-center justify-center border-none">
 					<LuTrophy className="h-12 w-12 text-yellow-500 mb-2" />
 					<div className="text-3xl font-bold mb-2">{highestScore}</div>
 					<p className="text-xs text-muted-foreground">最高点</p>
 				</Card>
 			</div>
-			<Card className="flex flex-col items-center shadow-none p-9">
+			<Card className="flex flex-col items-center border-none p-8">
 				<h2 className="text-2xl font-bold mb-4">過去のチャレンジ</h2>
-				{sortedMyScore.map((score) => (
-					<div
-						key={score.id}
-						className="flex w-full items-center mb-2 border rounded-md"
-					>
-						<img
-							src={score.imageUrl}
-							alt="チャレンジ画像"
-							className="w-1/4 h-auto rounded-l-md"
-						/>
-						<div className="flex flex-col items-start justify-center w-1/2 text-xs">
-							<div className="pl-4 flex flex-col gap-1">
-								<p className="font-bold">{score.assignment}</p>
-								<div className="flex items-center gap-1">
-									<LuClock />
-									<p className="pb-0.5">{score.answerTime}</p>
+				{sortedMyScore.length === 0 ? (
+					<div className="text-gray-500 text-center py-8">
+						<p>まだチャレンジの記録がありません</p>
+						<p className="text-sm mt-2">
+							新しいチャレンジに挑戦してみましょう！
+						</p>
+					</div>
+				) : (
+					sortedMyScore.map((score) => (
+						<div
+							key={score.id}
+							className="flex w-full items-center mb-2 border rounded-md"
+						>
+							<img
+								src={score.imageUrl}
+								alt="チャレンジ画像"
+								className="w-1/4 h-auto rounded-l-md"
+							/>
+							<div className="flex flex-col items-start justify-center w-1/2 text-xs">
+								<div className="pl-4 flex flex-col gap-1">
+									<p className="font-bold">{score.assignment}</p>
+									<div className="flex items-center gap-1">
+										<LuClock />
+										<p className="pb-0.5">{score.answerTime}</p>
+									</div>
 								</div>
 							</div>
+							<p className="w-1/4 text-lg font-bold">{score.point}点</p>
 						</div>
-						<p className="w-1/4 text-lg font-bold">{score.point}点</p>
-					</div>
-				))}
+					))
+				)}
 			</Card>
 		</div>
 	);

--- a/app/src/app/user/page.tsx
+++ b/app/src/app/user/page.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import type { MyScoreDetail, User } from "@/types";
 import { useEffect, useState } from "react";
 import { FiEdit2 } from "react-icons/fi";
@@ -11,6 +12,7 @@ import { VscAccount } from "react-icons/vsc";
 const UserPage = () => {
 	const [userData, setUserData] = useState<User>();
 	const [myScore, setMyScore] = useState<MyScoreDetail[]>([]);
+	const [isEditing, setIsEditing] = useState(false);
 
 	useEffect(() => {
 		const fetchData = async () => {
@@ -54,12 +56,36 @@ const UserPage = () => {
 				)}
 				<div className="ml-4 flex flex-col gap-1">
 					<div className="flex items-center">
-						<span className="text-xl font-bold text-[#333333]">
-							{userData.displayName || "user@example.com"}
-						</span>
-						<Button variant={"primary"} className="ml-2">
-							<FiEdit2 />
-						</Button>
+						{isEditing ? (
+							<div className="flex flex-col gap-2">
+								<Input type="text" placeholder="新しいユーザー名を入力" />
+								<div>
+									<Button variant={"default"} className="bg-[#333333]">
+										保存
+									</Button>
+									<Button
+										variant={"outline"}
+										className="ml-2"
+										onClick={() => setIsEditing(false)}
+									>
+										キャンセル
+									</Button>
+								</div>
+							</div>
+						) : (
+							<>
+								<span className="text-xl font-bold text-[#333333]">
+									{userData.displayName || "user@example.com"}
+								</span>
+								<Button
+									variant={"primary"}
+									className="ml-2"
+									onClick={() => setIsEditing(true)}
+								>
+									<FiEdit2 />
+								</Button>
+							</>
+						)}
 					</div>
 					<span className="text-xs text-[#8A8A8A]">{userData.email || ""}</span>
 				</div>

--- a/app/src/app/user/page.tsx
+++ b/app/src/app/user/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type { MyScoreDetail, User } from "@/types";
+import { useEffect, useState } from "react";
+import { FiEdit2 } from "react-icons/fi";
+import { LuClock, LuFlame, LuTrophy } from "react-icons/lu";
+import { VscAccount } from "react-icons/vsc";
+
+const calculateStreak = (scores: MyScoreDetail[]) => {
+	if (scores.length === 0) return 0;
+
+	// 日付でソート（新しい順）
+	const sortedScores = [...scores].sort((a, b) => {
+		return new Date(b.date).getTime() - new Date(a.date).getTime();
+	});
+
+	let currentStreak = 0;
+	const currentDate = new Date();
+
+	// 日付を年月日のみに変換する関数
+	const getDateOnly = (date: Date) => {
+		return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+	};
+
+	// 最新のスコアが今日または昨日でない場合はストリークなし
+	const latestScoreDate = new Date(sortedScores[0].date);
+	const today = getDateOnly(currentDate);
+	const yesterday = new Date(today);
+	yesterday.setDate(yesterday.getDate() - 1);
+
+	if (getDateOnly(latestScoreDate) < getDateOnly(yesterday)) {
+		return 0;
+	}
+
+	// 日付ごとにユニークな記録を取得
+	const uniqueDates = new Set<string>();
+
+	for (let i = 0; i < sortedScores.length; i++) {
+		const scoreDate = getDateOnly(new Date(sortedScores[i].date));
+		const dateStr = scoreDate.toISOString().split("T")[0];
+
+		if (!uniqueDates.has(dateStr)) {
+			const daysDiff = Math.floor(
+				(today.getTime() - scoreDate.getTime()) / (1000 * 60 * 60 * 24),
+			);
+
+			if (daysDiff === currentStreak) {
+				currentStreak++;
+				uniqueDates.add(dateStr);
+			} else {
+				break;
+			}
+		}
+	}
+
+	return currentStreak;
+};
+const calculateHighestScore = (scores: MyScoreDetail[]) => {
+	if (scores.length === 0) return 0;
+	return Math.max(...scores.map((score) => score.point));
+};
+
+const UserPage = () => {
+	const [userData, setUserData] = useState<User>();
+	const [myScore, setMyScore] = useState<MyScoreDetail[]>([]);
+	const [streak, setStreak] = useState(0);
+	const [highestScore, setHighestScore] = useState(0);
+
+	const sortedMyScore = myScore.sort((a, b) => {
+		return new Date(b.date).getTime() - new Date(a.date).getTime();
+	});
+
+	useEffect(() => {
+		const fetchData = async () => {
+			const userIdString = localStorage.getItem("userID");
+			if (!userIdString) {
+				window.location.href = "/login";
+				return;
+			}
+
+			try {
+				const userData = JSON.parse(userIdString);
+				setUserData(userData); // LocalStorageのユーザー情報を状態として保存
+
+				const response = await fetch(`/api/score/me/${userData.uid}`);
+				if (!response.ok) {
+					throw new Error("データの取得に失敗しました");
+				}
+
+				const data = await response.json();
+				setMyScore(data);
+				setStreak(calculateStreak(data));
+				setHighestScore(calculateHighestScore(data));
+			} catch (error) {
+				console.error("エラーが発生しました:", error);
+			}
+		};
+
+		fetchData();
+	}, []);
+
+	if (!userData) return null;
+	return (
+		<div className="w-screen h-screen flex flex-col gap-4 items-center p-4 pt-10">
+			<div className="flex items-center mb-4">
+				{userData.photoURL ? (
+					<img
+						src={userData.photoURL}
+						alt="User Icon"
+						className="w-16 h-16 rounded-full"
+					/>
+				) : (
+					<VscAccount className="w-16 h-16 text-[#333333]" />
+				)}
+				<div className="ml-4 flex flex-col gap-1">
+					<div className="flex items-center">
+						<span className="text-xl font-bold text-[#333333]">
+							{userData.displayName || "user@example.com"}
+						</span>
+						<Button variant={"primary"} className="ml-2">
+							<FiEdit2 />
+						</Button>
+					</div>
+					<span className="text-xs text-[#8A8A8A]">{userData.email || ""}</span>
+				</div>
+			</div>
+			<div className="flex justify-center gap-4 w-screen">
+				<Card className="w-40 h-40 flex flex-col items-center justify-center shadow-none">
+					<LuFlame className="h-12 w-12 text-orange-500 mb-2" />
+					<div className="text-3xl font-bold">{streak}日</div>
+					<p className="text-xs text-muted-foreground">継続記録</p>
+				</Card>
+				<Card className="w-40 h-40 flex flex-col items-center justify-center shadow-none">
+					<LuTrophy className="h-12 w-12 text-yellow-500 mb-2" />
+					<div className="text-3xl font-bold">{highestScore}</div>
+					<p className="text-xs text-muted-foreground">最高点</p>
+				</Card>
+			</div>
+			<Card className="flex flex-col items-center shadow-none p-9">
+				<h2 className="text-2xl font-bold mb-4">過去のチャレンジ</h2>
+				{sortedMyScore.map((score) => (
+					<div
+						key={score.id}
+						className="flex w-full items-center mb-2 border rounded-md"
+					>
+						<img
+							src={score.imageUrl}
+							alt="チャレンジ画像"
+							className="w-1/4 h-auto rounded-l-md"
+						/>
+						<div className="flex flex-col items-start justify-center w-1/2 text-xs">
+							<div className="pl-4 flex flex-col gap-1">
+								<p className="font-bold">{score.assignment}</p>
+								<div className="flex items-center gap-1">
+									<LuClock />
+									<p className="pb-0.5">{score.answerTime}</p>
+								</div>
+							</div>
+						</div>
+						<p className="w-1/4 text-lg font-bold">{score.point}点</p>
+					</div>
+				))}
+			</Card>
+		</div>
+	);
+};
+
+export default UserPage;

--- a/app/src/components/layout/footer.tsx
+++ b/app/src/components/layout/footer.tsx
@@ -25,7 +25,7 @@ const Footer = () => {
 	};
 
 	return (
-		<footer className="w-full flex justify-around py-2 shadow-[rgba(17,_17,_26,_0.1)_0px_0px_16px] fixed bottom-0 bg-white z-10">
+		<footer className="w-full flex justify-around py-2 shadow-[rgba(17,_17,_26,_0.1)_0px_0px_16px] sticky bottom-0 bg-white z-10">
 			<Button
 				variant={activeButton === "camera" ? "iconActive" : "iconDefault"}
 				className="flex flex-col items-center justify-center w-16 h-16"

--- a/app/src/components/layout/footer.tsx
+++ b/app/src/components/layout/footer.tsx
@@ -25,7 +25,7 @@ const Footer = () => {
 	};
 
 	return (
-		<footer className="w-full flex justify-around py-2 shadow-[rgba(17,_17,_26,_0.1)_0px_0px_16px] sticky bottom-0 bg-white z-10">
+		<footer className="w-full flex justify-around py-2 shadow-[rgba(17,_17,_26,_0.1)_0px_0px_16px] fixed bottom-0 bg-white z-10">
 			<Button
 				variant={activeButton === "camera" ? "iconActive" : "iconDefault"}
 				className="flex flex-col items-center justify-center w-16 h-16"

--- a/app/src/lib/signInAndUp.ts
+++ b/app/src/lib/signInAndUp.ts
@@ -1,50 +1,58 @@
-import type { User } from "@firebase/auth";
+import type { User } from "@/types";
+import type { User as FirebaseUser } from "@firebase/auth";
 
-export const signInOrUp = async (user: User) => {
-  try {
-    const res = await fetch(`/api/user/?uid=${user.uid}`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+const storeStorageUser = (user: User) => {
+	localStorage.setItem("userID", JSON.stringify(user));
+};
 
-    if (res.status === 200) {
-      storeStorageUser(user.uid);
-      toRoot();
-    } else {
-      await signUp(user); // 応答を待つ
-    }
-  } catch (error) {
-    console.error("エラーが発生しました:", error);
-  }
+export const signInOrUp = async (firebaseUser: FirebaseUser) => {
+	try {
+		const res = await fetch(`/api/user/?uid=${firebaseUser.uid}`, {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+
+		const user: User = {
+			uid: firebaseUser.uid,
+			displayName: firebaseUser.displayName,
+			email: firebaseUser.email,
+			photoURL: firebaseUser.photoURL,
+		};
+
+		if (res.status === 200) {
+			storeStorageUser(user);
+			toRoot();
+		} else {
+			await signUp(user);
+		}
+	} catch (error) {
+		console.error("エラーが発生しました:", error);
+	}
 };
 
 const signUp = async (user: User) => {
-  try {
-    const res = await fetch("/api/user/new", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(user),
-    });
+	try {
+		const res = await fetch("/api/user/new", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(user),
+		});
 
-    if (res.status === 200) {
-      storeStorageUser(user.uid);
-      toRoot();
-    } else {
-      throw new Error("ユーザー登録に失敗");
-    }
-  } catch (error) {
-    console.error("エラーが発生しました:", error);
-  }
-};
-
-const storeStorageUser = (uid: string) => {
-  localStorage.setItem("userID", uid);
+		if (res.status === 200) {
+			storeStorageUser(user);
+			toRoot();
+		} else {
+			throw new Error("ユーザー登録に失敗");
+		}
+	} catch (error) {
+		console.error("エラーが発生しました:", error);
+	}
 };
 
 const toRoot = () => {
-  window.location.href = "/";
+	window.location.href = "/";
 };

--- a/app/src/provider/SessionProvider.tsx
+++ b/app/src/provider/SessionProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { isValidUser } from "@/lib/isValidUser";
 import { signOut } from "@/lib/signOut";
+import type { User } from "@/types";
 import { useEffect } from "react";
 
 export interface SessionProviderProps {
@@ -21,7 +22,8 @@ const SessionProvider = ({ children }: SessionProviderProps) => {
 			return;
 		}
 
-		isValidUser(userId).then((res) => {
+		const parsedUser = JSON.parse(userId) as User;
+		isValidUser(parsedUser.uid).then((res) => {
 			if (!res) {
 				signOut();
 			}

--- a/app/src/types/index.tsx
+++ b/app/src/types/index.tsx
@@ -89,9 +89,11 @@ export type MyScoreDetail = {
   userName: string;
   imageUrl: string;
   point: number;
+  highestPoint: number;
   similarity: number;
   answerTime: string;
   date: string;
+  streakDays: number;
 };
 
 export type todayAssignment = {

--- a/app/src/types/index.tsx
+++ b/app/src/types/index.tsx
@@ -3,9 +3,10 @@
  */
 export type User = {
   displayName: string | null;
-  phoneNumber: string | null;
+  phoneNumber?: string | null;
+  email: string | null;
   photoURL: string | null;
-  providerId: string;
+  providerId?: string;
   uid: string;
 };
 /**
@@ -90,7 +91,9 @@ export type MyScoreDetail = {
   point: number;
   similarity: number;
   answerTime: string;
+  date: string;
 };
+
 export type todayAssignment = {
   assignmentId: number;
   english: string;


### PR DESCRIPTION
## 概要

ユーザーページの作成

## 変更内容

- 新しく`/app/user`にページを追加しました。
- ユーザーデータを追加で取得するため、localStorageに追加でatuhのデータが保存されるように変更しました。

## 動作確認

- [ ]  ユーザーページが表示される。
- [ ] ユーザー情報が反映される。
- [ ] 継続日数、最高点、チャレンジの記録が正常に表示される。

<img src="https://github.com/user-attachments/assets/95c22f6d-9dfc-4f5a-8d73-1ed1d7b01601" width="30%" />
<img src="https://github.com/user-attachments/assets/fe2c2cb0-9c1a-4140-b4b4-5bb2bb03c3b9" width="30%" />


## 関連するIssue

- #33

## 備考
もしかしたら、localStorageの`userID`を一度消さないとかもです。
名前変更は実装されていません。ただのボタンです。