### PR TITLE
EXPスキーマを作成&ユーザサインアップ、サインイン時にテーブル作成。

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   email String
   photoUrl String
   scores Score[]
+  experiencePoint ExperiencePoint? @relation()
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
@@ -61,4 +62,17 @@ model Word {
   updatedAt DateTime @default(now())  @updatedAt
 
   assignment Assignment[]
+}
+
+model ExperiencePoint {
+  id Int @id @default(autoincrement())
+  speedPoint Int
+  similarityPoint Int
+  totalPoint Int
+  continuationDay Int
+  userId Int @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
 }

--- a/app/src/app/api/experiencePoint/new/route.ts
+++ b/app/src/app/api/experiencePoint/new/route.ts
@@ -1,0 +1,33 @@
+import type { experiencePoint } from "@/types";
+import { prisma } from "@lib/prisma";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+// experiencePointの新規作成
+export async function POST(req: NextRequest) {
+	const reader = req.body?.getReader();
+	if (!reader) {
+		return NextResponse.json(
+			{ error: "No request body found" },
+			{ status: 400 },
+		);
+	}
+	const { value } = await reader.read();
+	const userId = new TextDecoder().decode(value);
+
+	const id = JSON.parse(userId);
+	const createExp: experiencePoint = await prisma.experiencePoint.create({
+		data: {
+			speedPoint: 0,
+			similarityPoint: 0,
+			totalPoint: 0,
+			continuationDay: 0,
+			userId: id,
+		},
+	});
+
+	return new Response(JSON.stringify({ createExp }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}

--- a/app/src/app/api/image/route.ts
+++ b/app/src/app/api/image/route.ts
@@ -1,77 +1,69 @@
-import type { NextApiResponse } from "next";
 import type { NextRequest } from "next/server";
 
 import { OpenAI } from "openai";
 
-type ResponseData = {
-  message: string;
-};
-
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+	apiKey: process.env.OPENAI_API_KEY,
 });
 
 const BUCKET_NAME = "kz2404";
 
-export async function GET(
-  req: NextRequest,
-  res: NextApiResponse<ResponseData>
-) {
-  	// クエリパラメータを取得
+export async function GET(req: NextRequest) {
+	// クエリパラメータを取得
 	const { searchParams } = new URL(req.url || "");
 	const imageName = searchParams.get("imageName") || "default-image-name";
-  const imageURL = `${process.env.NEXT_PUBLIC_MINIO_ENDPOINT}${BUCKET_NAME}/${imageName}`;
+	const imageURL = `${process.env.NEXT_PUBLIC_MINIO_ENDPOINT}${BUCKET_NAME}/${imageName}`;
 
-  return await generateCaption(imageURL)
-    .then((caption) => {
-      console.log(caption);
-      return new Response(JSON.stringify({ caption }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    })
-    .catch((error) => {
-      console.error("Error generating caption:", error);
-      return new Response(JSON.stringify({ message: "エラーが発生しました" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
-    });
+	return await generateCaption(imageURL)
+		.then((caption) => {
+			console.log(caption);
+			return new Response(JSON.stringify({ caption }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		})
+		.catch((error) => {
+			console.error("Error generating caption:", error);
+			return new Response(JSON.stringify({ message: "エラーが発生しました" }), {
+				status: 500,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
 }
 
 // 画像URLからキャプションを生成する関数
 export const generateCaption = async (imageUrl: string) => {
-  try {
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4o",
-      messages: [
-        {
-          role: "system",
-          content: [
-            {
-              type: "text",
-              text: "A robot that can generate very short captions for images.",
-            },
-          ],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "image_url",
-              image_url: {
-                url: imageUrl,
-                detail: "low",
-              },
-            },
-          ],
-        },
-      ],
-    });
+	try {
+		const completion = await openai.chat.completions.create({
+			model: "gpt-4o",
+			messages: [
+				{
+					role: "system",
+					content: [
+						{
+							type: "text",
+							text: "A robot that can generate very short captions for images.",
+						},
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "image_url",
+							image_url: {
+								url: imageUrl,
+								detail: "low",
+							},
+						},
+					],
+				},
+			],
+		});
 
-    const caption = await completion.choices[0].message.content;
-    return caption;
-  } catch (error) {
-    console.error("Error generating caption:", error);
-  }
+		const caption = await completion.choices[0].message.content;
+		return caption;
+	} catch (error) {
+		console.error("Error generating caption:", error);
+	}
 };

--- a/app/src/app/api/image/route.ts
+++ b/app/src/app/api/image/route.ts
@@ -1,69 +1,77 @@
+import type { NextApiResponse } from "next";
 import type { NextRequest } from "next/server";
 
 import { OpenAI } from "openai";
 
+type ResponseData = {
+  message: string;
+};
+
 const openai = new OpenAI({
-	apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
 const BUCKET_NAME = "kz2404";
 
-export async function GET(req: NextRequest) {
-	// クエリパラメータを取得
+export async function GET(
+  req: NextRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  	// クエリパラメータを取得
 	const { searchParams } = new URL(req.url || "");
 	const imageName = searchParams.get("imageName") || "default-image-name";
-	const imageURL = `${process.env.NEXT_PUBLIC_MINIO_ENDPOINT}${BUCKET_NAME}/${imageName}`;
+  const imageURL = `${process.env.NEXT_PUBLIC_MINIO_ENDPOINT}${BUCKET_NAME}/${imageName}`;
 
-	return await generateCaption(imageURL)
-		.then((caption) => {
-			console.log(caption);
-			return new Response(JSON.stringify({ caption }), {
-				status: 200,
-				headers: { "Content-Type": "application/json" },
-			});
-		})
-		.catch((error) => {
-			console.error("Error generating caption:", error);
-			return new Response(JSON.stringify({ message: "エラーが発生しました" }), {
-				status: 500,
-				headers: { "Content-Type": "application/json" },
-			});
-		});
+  return await generateCaption(imageURL)
+    .then((caption) => {
+      console.log(caption);
+      return new Response(JSON.stringify({ caption }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    })
+    .catch((error) => {
+      console.error("Error generating caption:", error);
+      return new Response(JSON.stringify({ message: "エラーが発生しました" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
 }
 
 // 画像URLからキャプションを生成する関数
 export const generateCaption = async (imageUrl: string) => {
-	try {
-		const completion = await openai.chat.completions.create({
-			model: "gpt-4o",
-			messages: [
-				{
-					role: "system",
-					content: [
-						{
-							type: "text",
-							text: "A robot that can generate very short captions for images.",
-						},
-					],
-				},
-				{
-					role: "user",
-					content: [
-						{
-							type: "image_url",
-							image_url: {
-								url: imageUrl,
-								detail: "low",
-							},
-						},
-					],
-				},
-			],
-		});
+  try {
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "system",
+          content: [
+            {
+              type: "text",
+              text: "A robot that can generate very short captions for images.",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: {
+                url: imageUrl,
+                detail: "low",
+              },
+            },
+          ],
+        },
+      ],
+    });
 
-		const caption = await completion.choices[0].message.content;
-		return caption;
-	} catch (error) {
-		console.error("Error generating caption:", error);
-	}
+    const caption = await completion.choices[0].message.content;
+    return caption;
+  } catch (error) {
+    console.error("Error generating caption:", error);
+  }
 };

--- a/app/src/app/api/user/new/route.ts
+++ b/app/src/app/api/user/new/route.ts
@@ -1,49 +1,57 @@
-import type { NextRequest } from "next/server";
-import { prisma } from "@lib/prisma";
 import type { DBUser as User } from "@/types";
+import { prisma } from "@lib/prisma";
+import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 type ResponseData = {
-  message: string;
+	message: string;
 };
 
 // GETメソッドのハンドラ関数
 export function GET() {
-  // 疎通確認
-  return new Response(JSON.stringify({ message: "Hello from Next.js!" }), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+	// 疎通確認
+	return new Response(JSON.stringify({ message: "Hello from Next.js!" }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
 }
 
 // POSTメソッドをサポートしたい場合（例）
 export async function POST(req: NextRequest) {
-  const reader = req.body?.getReader();
-  if (!reader) {
-    return NextResponse.json(
-      { error: "No request body found" },
-      { status: 400 }
-    );
-  }
-  const { value } = await reader.read();
-  const userData = new TextDecoder().decode(value);
+	const reader = req.body?.getReader();
+	if (!reader) {
+		return NextResponse.json(
+			{ error: "No request body found" },
+			{ status: 400 },
+		);
+	}
+	const { value } = await reader.read();
+	const userData = new TextDecoder().decode(value);
 
-  // 任意の処理をここで行います（例: データのパース）  const userData = new TextDecoder().decode(value);
-  // TODO ここバリデーション欲しい
-  const user = JSON.parse(userData);
-  // プリズマでユーザを登録
-  const registerUser: User = await prisma.user.create({
-    data: {
-      uid: user.uid,
-      name: user.displayName,
-      email: user.email,
-      photoUrl: user.photoURL,
-    },
-  });
+	// 任意の処理をここで行います（例: データのパース）  const userData = new TextDecoder().decode(value);
+	// TODO ここバリデーション欲しい
+	const user = JSON.parse(userData);
+	// プリズマでユーザ,経験値を登録
+	const registerUser: User = await prisma.user.create({
+		data: {
+			uid: user.uid,
+			name: user.displayName,
+			email: user.email,
+			photoUrl: user.photoURL,
+			experiencePoint: {
+				create: {
+					speedPoint: 0,
+					similarityPoint: 0,
+					totalPoint: 0,
+					continuationDay: 0,
+				},
+			},
+		},
+	});
 
-  // 疎通確認
-  return new Response(JSON.stringify({ registerUser }), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+	// 疎通確認
+	return new Response(JSON.stringify({ registerUser }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
 }

--- a/app/src/lib/signInAndUp.ts
+++ b/app/src/lib/signInAndUp.ts
@@ -23,6 +23,10 @@ export const signInOrUp = async (firebaseUser: FirebaseUser) => {
 
 		if (res.status === 200) {
 			storeStorageUser(user);
+			const userData = await res.json();
+			if (!userData.experiencePoint) {
+				await createExp(userData.id);
+			}
 			toRoot();
 		} else {
 			await signUp(user);
@@ -47,6 +51,26 @@ const signUp = async (user: User) => {
 			toRoot();
 		} else {
 			throw new Error("ユーザー登録に失敗");
+		}
+	} catch (error) {
+		console.error("エラーが発生しました:", error);
+	}
+};
+
+const createExp = async (userId: number) => {
+	try {
+		const res = await fetch("/api/experiencePoint/new", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(userId),
+		});
+
+		if (res.status === 200) {
+			toRoot();
+		} else {
+			throw new Error("作成に失敗しました");
 		}
 	} catch (error) {
 		console.error("エラーが発生しました:", error);

--- a/app/src/types/index.tsx
+++ b/app/src/types/index.tsx
@@ -103,7 +103,19 @@ export type todayAssignment = {
 };
 
 export type latestAssignment = {
-  assignmentId: number;
-  english: string;
+	assignmentId: number;
+	english: string;
+};
 
-}
+export type experiencePoint = {
+	id: number;
+	speedPoint: number;
+	similarityPoint: number;
+	totalPoint: number;
+	continuationDay: number;
+	userId: number;
+	createdAt: Date;
+	updatedAt: Date;
+
+	user?: User;
+};


### PR DESCRIPTION
## 概要
経験値を新たに作りポイント付与でスコアを伸ばせるようにしたい。
そのための経験値を保管するためのスキーマを新しく作成しました。

## 変更内容
スキーマの作成
    - id
    - 速さに割り振ったポイント
    - 類似度に割り振ったポイント
    - 所持ポイント
    - 継続日数を保管する
    - userID
        - 紐づくユーザのポイント管理
   
experiencePoint createAPIの作成
- api/experiencePoint/new/troute.ts

サインアップ時にに使用するユーザ作成のAPIに追加でexperiencePointを作成させるように修正
- api/user/new/route.ts

サインイン時でまだexperiencePointが作成されていない場合、api/experiencePoint/new/を叩くように修正。

## 動作確認

- どのような手順で動作確認を行ったのか記述してください。
/loginでサインインしたり、新しいアカウントでサインアップしたら追加されていると思います。

以下、studio内
![image](https://github.com/user-attachments/assets/d5bc5a85-a5a8-4066-9981-4595a4b9724c)

## 関連するIssue

- 関連するIssue番号を記載してください。例: `#123`

## 備考

- その他、レビュワーに伝えたいことがあれば記述してください。
